### PR TITLE
fix xtend migration of esa-cdk generator

### DIFF
--- a/packages/xsmp-profile-esa-cdk/src/generator.ts
+++ b/packages/xsmp-profile-esa-cdk/src/generator.ts
@@ -234,7 +234,7 @@ export class EsaCdkGenerator extends GapPatternCppGenerator {
             includes.push(`esa/ecss/smp/cdk/${type.$type}.h`);
         }
         if (this.hasInvokableMembers(type)) {
-            includes.push('map');
+            includes.push('map', 'Smp/IRequest.h', 'esa/ecss/smp/cdk/Request.h', 'esa/ecss/smp/cdk/RequestContainer.h');
         }
         if (type.elements.some(ast.isContainer)) {
             includes.push('esa/ecss/smp/cdk/Composite.h');
@@ -266,33 +266,90 @@ export class EsaCdkGenerator extends GapPatternCppGenerator {
         return s`
             ${this.comment(type)}class ${type.name}: public ${type.name}Gen {
             public:
-                /// Constructor setting name, description and parent.
-                /// @param name Name of new model instance.
-                /// @param description Description of new model instance.
-                /// @param parent Parent of new model instance.
-                /// @param type_registry Reference to global type registry.
-                ${type.name}(
-                        ::Smp::String8 name,
-                        ::Smp::String8 description,
-                        ::Smp::IObject* parent,
-                        ::Smp::Publication::ITypeRegistry* type_registry);
+                /// Re-use parent constructor
+                using ${type.name}Gen::${type.name}Gen;
                 
                 /// Virtual destructor to release memory.
                 ~${type.name}() noexcept override = default;
-            
-                ${this.declareMembers(type, VisibilityKind.public)}
+                
+            private:
+                // ${type.name}Gen call DoPublish/DoConfigure/DoConnect/DoDisconnect
+                friend class ${this.fqn(type)}Gen;
+                
+                /// Publish fields, operations and properties of the ${type.$type}.
+                /// @param receiver Publication receiver.
+                void DoPublish(::Smp::IPublication* receiver);
+                
+                /// Perform any custom configuration of the ${type.$type}.
+                /// @param logger Logger to use for log messages during Configure().
+                /// @param linkRegistry Link Registry to use for registration of
+                ///         links created during Configure() or later.
+                void DoConfigure(::Smp::Services::ILogger* logger, ::Smp::Services::ILinkRegistry* linkRegistry);
+                
+                /// Connect the ${type.$type} to the simulator and its simulation
+                /// services.
+                /// @param simulator Simulation Environment that hosts the ${type.$type}.
+                void DoConnect(::Smp::ISimulator* simulator);
+                
+                /// Disconnect the ${type.$type} from the simulator and all its
+                /// simulation services.
+                void DoDisconnect();
+                
+                ${this.declareMembers(type, VisibilityKind.private)}
             };
             `;
+    }
+
+    override async generateStructureHeaderGen(type: ast.Structure, gen: boolean): Promise<string | undefined> {
+        const fields = type.elements.filter(ast.isField).filter(field => !this.attrHelper.isStatic(field));
+        const hasConstructor = fields.some(field => field.default !== undefined);
+        const name = this.name(type, gen);
+        const constructorDeclaration = hasConstructor ? s`
+            ${name}() = default;
+            ~${name}() = default;
+            ${name}(const ${name}&) = default;
+            ${name}(${name}&&) = default;
+            ${name}(${fields.map(field => `${this.fqn(field.type.ref)} ${field.name}`).join(', ')}):
+            ${fields.map(field => `${field.name}(${field.name})`).join(', ')} {}
+            ${name}& operator=(const ${name}&) = default;
+        ` : undefined;
+
+        return s`
+        ${this.comment(type)}struct ${name}
+        {
+           ${this.declareMembersGen(type, VisibilityKind.public, gen)}
+
+            ${constructorDeclaration}
+
+            static void _Register(::Smp::Publication::ITypeRegistry* registry);
+        };
+        
+        ${this.uuidDeclaration(type)}
+        `;
     }
 
     protected override componentBase(type: ast.Component): string | undefined {
         return type.base ? this.fqn(type.base.ref) : `::esa::ecss::smp::cdk::${type.$type}`;
     }
     private hasInvokableMembers(type: ast.Component): boolean {
-        return type.elements.filter(ast.isInvokable).some(element => this.isInvokable(element));
+        return this.getInvokableOperations(type).length > 0;
     }
     private getInvokableOperations(type: ast.Component): ast.Operation[] {
         return type.elements.filter(ast.isOperation).filter(operation => this.isInvokable(operation));
+    }
+    protected override isInvokable(element: ast.Invokable): boolean {
+        if (!ast.isOperation(element)) {
+            return super.isInvokable(element);
+        }
+        if (!super.isInvokable(element)) {
+            return false;
+        }
+        return this.attrHelper.getViewKind(element) !== undefined
+            && element.parameter.every(param =>
+                ast.isSimpleType(param.type.ref)
+                && !ast.isStringType(param.type.ref)
+                && param.direction !== 'out'
+                && param.direction !== 'inout');
     }
     protected override componentBases(type: ast.Component): string[] {
         const bases = super.componentBases(type);
@@ -312,6 +369,33 @@ export class EsaCdkGenerator extends GapPatternCppGenerator {
     override async generateComponentHeaderGen(type: ast.Component, gen: boolean): Promise<string | undefined> {
         const name = this.name(type, gen);
         const bases = this.componentBases(type);
+        const hasInvokableMembers = this.hasInvokableMembers(type);
+        const requestHandlerDeclarations = hasInvokableMembers ? s`
+            private:
+                template <typename _Type> static void PopulateRequestHandlers(_Type* bluePrint, typename ::esa::ecss::smp::cdk::RequestContainer<_Type>::Map& handlers);
+                static ::esa::ecss::smp::cdk::RequestContainer<${name}>::Map requestHandlers;
+
+            public:
+                /// Dynamically invoke an operation using a request object that has 
+                /// been created and filled with parameter values by the caller.
+                /// @param   request Request object to invoke.
+                /// @throws  Smp::InvalidOperationName
+                /// @throws  Smp::InvalidParameterCount
+                /// @throws  Smp::InvalidParameterType
+                void Invoke(::Smp::IRequest* request) override;
+            ` : undefined;
+        const populateRequestHandlersDefinition = hasInvokableMembers ? s`
+            template <typename _Type>
+            void ${name}::PopulateRequestHandlers(_Type* bluePrint, typename ::esa::ecss::smp::cdk::RequestContainer<_Type>::Map& handlers) 
+            {
+                typedef ::esa::ecss::smp::cdk::RequestContainer<_Type> Help;
+                
+                // ---- Operations ----
+                ${this.getInvokableOperations(type).map(operation => this.generateRqHandlerOperation(operation, gen)).join('\n')}
+                
+                ::esa::ecss::smp::cdk::${type.$type}::PopulateRequestHandlers<_Type>(bluePrint, handlers);
+            }
+            ` : undefined;
         return s`
             ${this.uuidDeclaration(type)}
             
@@ -338,7 +422,7 @@ export class EsaCdkGenerator extends GapPatternCppGenerator {
             ${name}& operator=(${name}&&) = delete;
             
             /// Virtual destructor to release memory.
-            ~${name}() override = default;
+            ~${name}() override;
             
             /// Request the ${type.$type} to publish its fields, properties and 
             /// operations against the provided publication receiver.
@@ -371,37 +455,12 @@ export class EsaCdkGenerator extends GapPatternCppGenerator {
             /// Get Universally Unique Identifier of the ${type.$type}.
             /// @return  Universally Unique Identifier of the ${type.$type}.
             const ::Smp::Uuid& GetUuid() const override;
-            ${this.hasInvokableMembers(type) ? `
-            private:
-                template <typename _Type> static void PopulateRequestHandlers(_Type* bluePrint, typename ::esa::ecss::smp::cdk::RequestContainer<_Type>::Map& handlers);
-                static ::esa::ecss::smp::cdk::RequestContainer<${name}>::Map requestHandlers;
-
-            public:
-                /// Dynamically invoke an operation using a request object that has 
-                /// been created and filled with parameter values by the caller.
-                /// @param   request Request object to invoke.
-                /// @throws  Smp::InvalidOperationName
-                /// @throws  Smp::InvalidParameterCount
-                /// @throws  Smp::InvalidParameterType
-                void Invoke(::Smp::IRequest* request) override;
-            `: undefined}
+            ${requestHandlerDeclarations}
             
             ${this.declareMembersGen(type, VisibilityKind.public, gen)}
             };
 
-            ${this.hasInvokableMembers(type) ? `
-            template <typename _Type>
-            void ${name}::PopulateRequestHandlers(_Type* bluePrint, typename ::esa::ecss::smp::cdk::RequestContainer<_Type>::Map& handlers) 
-            {
-                typedef ::esa::ecss::smp::cdk::RequestContainer<_Type> Help;
-                
-                // ---- Operations ----
-                ${this.getInvokableOperations(type).map(operation => this.generateRqHandlerOperation(operation, gen)).join('\n')}
-                
-                ::esa::ecss::smp::cdk::«t.eClass.name»::PopulateRequestHandlers<_Type>(bluePrint, handlers);
-            }
-
-                `: undefined}
+            ${populateRequestHandlersDefinition}
 
             `;
     }
@@ -411,6 +470,28 @@ export class EsaCdkGenerator extends GapPatternCppGenerator {
         const base = this.componentBase(type);
         const fqn = this.fqn(type);
         const initializer = this.initializeMembers(type, gen);
+        const hasInvokableMembers = this.hasInvokableMembers(type);
+        const populateRequestHandlers = hasInvokableMembers ? s`
+            if (requestHandlers.empty()) {
+                PopulateRequestHandlers<${name}>(this, requestHandlers);
+            }
+            ` : undefined;
+        const requestHandlerDefinitions = hasInvokableMembers ? s`
+            ::esa::ecss::smp::cdk::RequestContainer<${name}>::Map ${name}::requestHandlers;
+
+            void ${name}::Invoke(::Smp::IRequest* request) {
+                if (!request) {
+                    return;
+                }
+                auto it = requestHandlers.find(request->GetOperationName());
+                if (it != requestHandlers.end()) {
+                    it->second->Execute(*this, request);
+                } else {
+                    // pass the request down to the base class
+                    ${base}::Invoke(request);
+                }
+            }
+            ` : undefined;
         return s`
             //--------------------------- Constructor -------------------------
             ${name}::${name}(
@@ -433,9 +514,7 @@ export class EsaCdkGenerator extends GapPatternCppGenerator {
                 // Call parent class implementation first
                 ${base}::Publish(receiver);
                 
-                if (requestHandlers.empty()) {
-                    PopulateRequestHandlers<${name}>(this, requestHandlers);
-                }
+                ${populateRequestHandlers}
                 
                 ${this.publishMembers(type)}
                 
@@ -465,33 +544,7 @@ export class EsaCdkGenerator extends GapPatternCppGenerator {
                 ${base}::Disconnect();
             }
 
-            void ${name}::DoPublish(::Smp::IPublication*) {
-            }
-            
-            void ${name}::DoConfigure( ::Smp::Services::ILogger*, ::Smp::Services::ILinkRegistry*){
-            }
-            
-            void ${name}::DoConnect( ::Smp::ISimulator*){
-            }
-            
-            void ${name}::DoDisconnect(){
-            }
-
-            ${this.hasInvokableMembers(type) ? `                
-                void ${name}::Invoke(::Smp::IRequest* request) {
-                    if (!request) {
-                        return;
-                    }
-                    if (auto it = _requestHandlers.find(request->GetOperationName());
-                            it != _requestHandlers.end()) {
-                        it->second(this, request);
-                    } else {
-                        // pass the request down to the base class
-                        ${base}::Invoke(request);
-                    }
-                }
-
-                `: undefined}
+            ${requestHandlerDefinitions}
             const ::Smp::Uuid& ${name}::GetUuid() const {
                 return Uuid_${type.name};
             }
@@ -502,55 +555,18 @@ export class EsaCdkGenerator extends GapPatternCppGenerator {
 
     protected generateRqHandlerOperation(op: ast.Operation, _gen: boolean): string {
         const r = op.returnParameter;
-        const invokation = `component.${this.operationName(op)}(${op.parameter.map(param => `${this.attrHelper.isByPointer(param) ? '&' : ''}p_${param.name}`).join(', ')})`;
+        const returnType = this.type(r);
+        const parameterTypes = op.parameter.map(param => this.type(param));
+        const templateArguments = [returnType, ...parameterTypes].join(', ');
+        const containerType = this.name(op.$container, _gen);
+        const pointerType = `${returnType} (${containerType}::*)(${parameterTypes.join(', ')})${this.attrHelper.isConst(op) ? ' const' : ''}`;
         return s`
-           Help::template AddIfMissing<«IF o.returnParameter !== null»«o.returnParameter.type()»«ELSE»void«ENDIF»«FOR param : o.parameter BEFORE ', ' SEPARATOR ', '»«param.type()»«ENDFOR»>(
+            Help::template AddIfMissing<${templateArguments}>(
                 handlers,
                 "${op.name}",
                 ${this.primitiveTypeKind(r?.type.ref)},
-                static_cast<«IF o.returnParameter !== null»«o.returnParameter.type()»«ELSE»void«ENDIF»(«container.name(useGenPattern)»::*)(«FOR param : o.parameter SEPARATOR ', '»«param.type()»«ENDFOR»)«IF o.isConst»const«ENDIF»>(&«container.name(useGenPattern)»::«o.name»));
-       
-            if (handlers.find("${op.name}") == handlers.end()) {
-                handlers["${op.name}"] = [](_Type & component, [[maybe_unused]] ::Smp::IRequest* request) {
-                ${op.parameter.map(param => this.initParameter(param)).join('\n')}
-                /// Invoke ${op.name}
-                ${r ? `request->SetReturnValue({${this.primitiveTypeKind(r.type.ref)}, ${invokation}})` : `${invokation}`};
-                ${op.parameter.map(param => this.setParameter(param)).join('\n')}
-                };
-            }
+                static_cast<${pointerType}>(&${containerType}::${this.operationName(op)}));
             `;
-    }
-    /*protected override isInvokable(element: ast.Invokable): boolean {
-        if (ast.isOperation(element)) {
-            if (element.returnParameter && !ast.isSimpleType(element.returnParameter.type.ref)) {
-                return false;
-            }
-            return element.parameter.every(param => ast.isValueType(param.type.ref) && !ast.isClass(param.type.ref));
-        }
-        return super.isInvokable(element);
-    }*/
-
-    initParameter(param: ast.Parameter): string {
-        switch (param.direction ?? 'in') {
-            case 'out':
-                // only declare the parameter
-                return `${this.fqn(param.type.ref)} p_${param.name}${param.default ? this.directListInitializer(param.default) : ''};`;
-            case 'in':
-            case 'inout':
-                // declare and initialize the parameter
-                return `auto p_${param.name} = static_cast<${this.fqn(param.type.ref)}>(request->GetParameterValue(req->GetParameterIndex("${param.name}")));`;
-        }
-    }
-
-    setParameter(param: ast.Parameter): string | undefined {
-        switch (param.direction ?? 'in') {
-            case 'out':
-            case 'inout':
-                return `request->SetParameterValue(request->GetParameterIndex("${param.name}"), p_${param.name});`;
-            case 'in':
-                // do nothing
-                return undefined;
-        }
     }
 
 }

--- a/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/ChildModelGen.cpp
+++ b/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/ChildModelGen.cpp
@@ -37,9 +37,6 @@ namespace demo
             // Call parent class implementation first
             ::esa::ecss::smp::cdk::Model::Publish(receiver);
 
-            if (requestHandlers.empty()) {
-                PopulateRequestHandlers<ChildModelGen>(this, requestHandlers);
-            }
 
             // Publish field childState
             receiver->PublishField(
@@ -76,18 +73,6 @@ namespace demo
 
             // Call parent implementation last, to remove references to the Simulator and its services
             ::esa::ecss::smp::cdk::Model::Disconnect();
-        }
-
-        void ChildModelGen::DoPublish(::Smp::IPublication*) {
-        }
-
-        void ChildModelGen::DoConfigure( ::Smp::Services::ILogger*, ::Smp::Services::ILinkRegistry*){
-        }
-
-        void ChildModelGen::DoConnect( ::Smp::ISimulator*){
-        }
-
-        void ChildModelGen::DoDisconnect(){
         }
 
         const ::Smp::Uuid& ChildModelGen::GetUuid() const {

--- a/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/ChildModelGen.h
+++ b/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/ChildModelGen.h
@@ -63,7 +63,7 @@ namespace demo
         ChildModelGen& operator=(ChildModelGen&&) = delete;
 
         /// Virtual destructor to release memory.
-        ~ChildModelGen() override = default;
+        ~ChildModelGen() override;
 
         /// Request the Model to publish its fields, properties and
         /// operations against the provided publication receiver.

--- a/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/DeviceBase.h
+++ b/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/DeviceBase.h
@@ -29,8 +29,8 @@ namespace demo
         public:
             static void _Register(::Smp::Publication::ITypeRegistry* registry);
 
-            //«IF constructor»DeviceBase () = default;«ENDIF»
-            //«IF destructor»~DeviceBase () noexcept = default;«ENDIF»
+            //DeviceBase () = default;
+            //~DeviceBase () noexcept = default;
             //DeviceBase (const DeviceBase &) = default;
 
            private:

--- a/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/DeviceError.h
+++ b/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/DeviceError.h
@@ -28,8 +28,8 @@ namespace demo
         public:
             static void _Register(::Smp::Publication::ITypeRegistry* registry);
 
-            //«IF constructor»DeviceError () = default;«ENDIF»
-            //«IF destructor»~DeviceError () noexcept = default;«ENDIF»
+            //DeviceError () = default;
+            //~DeviceError () noexcept = default;
             //DeviceError (const DeviceError &) = default;
 
 

--- a/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/MonitorServiceGen.cpp
+++ b/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/MonitorServiceGen.cpp
@@ -96,33 +96,20 @@ namespace demo
             ::esa::ecss::smp::cdk::Service::Disconnect();
         }
 
-        void MonitorServiceGen::DoPublish(::Smp::IPublication*) {
+        ::esa::ecss::smp::cdk::RequestContainer<MonitorServiceGen>::Map MonitorServiceGen::requestHandlers;
+
+        void MonitorServiceGen::Invoke(::Smp::IRequest* request) {
+            if (!request) {
+                return;
+            }
+            auto it = requestHandlers.find(request->GetOperationName());
+            if (it != requestHandlers.end()) {
+                it->second->Execute(*this, request);
+            } else {
+                // pass the request down to the base class
+                ::esa::ecss::smp::cdk::Service::Invoke(request);
+            }
         }
-
-        void MonitorServiceGen::DoConfigure( ::Smp::Services::ILogger*, ::Smp::Services::ILinkRegistry*){
-        }
-
-        void MonitorServiceGen::DoConnect( ::Smp::ISimulator*){
-        }
-
-        void MonitorServiceGen::DoDisconnect(){
-        }
-
-
-                        void MonitorServiceGen::Invoke(::Smp::IRequest* request) {
-                            if (!request) {
-                                return;
-                            }
-                            if (auto it = _requestHandlers.find(request->GetOperationName());
-                                    it != _requestHandlers.end()) {
-                                it->second(this, request);
-                            } else {
-                                // pass the request down to the base class
-                                ::esa::ecss::smp::cdk::Service::Invoke(request);
-                            }
-                        }
-
-
         const ::Smp::Uuid& MonitorServiceGen::GetUuid() const {
             return Uuid_MonitorService;
         }

--- a/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/MonitorServiceGen.h
+++ b/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/MonitorServiceGen.h
@@ -23,9 +23,12 @@ namespace demo
 // --------------------------- Include Header Files ---------------------------
 // ----------------------------------------------------------------------------
 
+#include <esa/ecss/smp/cdk/Request.h>
+#include <esa/ecss/smp/cdk/RequestContainer.h>
 #include <esa/ecss/smp/cdk/Service.h>
 #include <map>
 #include <Smp/IComposite.h>
+#include <Smp/IRequest.h>
 #include <Smp/ISimulator.h>
 #include <Smp/PrimitiveTypes.h>
 #include <Smp/Publication/ITypeRegistry.h>
@@ -64,7 +67,7 @@ namespace demo
         MonitorServiceGen& operator=(MonitorServiceGen&&) = delete;
 
         /// Virtual destructor to release memory.
-        ~MonitorServiceGen() override = default;
+        ~MonitorServiceGen() override;
 
         /// Request the Service to publish its fields, properties and
         /// operations against the provided publication receiver.
@@ -97,20 +100,18 @@ namespace demo
         /// Get Universally Unique Identifier of the Service.
         /// @return  Universally Unique Identifier of the Service.
         const ::Smp::Uuid& GetUuid() const override;
+        private:
+            template <typename _Type> static void PopulateRequestHandlers(_Type* bluePrint, typename ::esa::ecss::smp::cdk::RequestContainer<_Type>::Map& handlers);
+            static ::esa::ecss::smp::cdk::RequestContainer<MonitorServiceGen>::Map requestHandlers;
 
-                    private:
-                        template <typename _Type> static void PopulateRequestHandlers(_Type* bluePrint, typename ::esa::ecss::smp::cdk::RequestContainer<_Type>::Map& handlers);
-                        static ::esa::ecss::smp::cdk::RequestContainer<MonitorServiceGen>::Map requestHandlers;
-
-                    public:
-                        /// Dynamically invoke an operation using a request object that has
-                        /// been created and filled with parameter values by the caller.
-                        /// @param   request Request object to invoke.
-                        /// @throws  Smp::InvalidOperationName
-                        /// @throws  Smp::InvalidParameterCount
-                        /// @throws  Smp::InvalidParameterType
-                        void Invoke(::Smp::IRequest* request) override;
-
+        public:
+            /// Dynamically invoke an operation using a request object that has
+            /// been created and filled with parameter values by the caller.
+            /// @param   request Request object to invoke.
+            /// @throws  Smp::InvalidOperationName
+            /// @throws  Smp::InvalidParameterCount
+            /// @throws  Smp::InvalidParameterType
+            void Invoke(::Smp::IRequest* request) override;
 
         private:
         /// Get Running.
@@ -123,32 +124,20 @@ namespace demo
         ::Smp::Bool running;
         };
 
+        template <typename _Type>
+        void MonitorServiceGen::PopulateRequestHandlers(_Type* bluePrint, typename ::esa::ecss::smp::cdk::RequestContainer<_Type>::Map& handlers)
+        {
+            typedef ::esa::ecss::smp::cdk::RequestContainer<_Type> Help;
 
-                    template <typename _Type>
-                    void MonitorServiceGen::PopulateRequestHandlers(_Type* bluePrint, typename ::esa::ecss::smp::cdk::RequestContainer<_Type>::Map& handlers)
-                    {
-                        typedef ::esa::ecss::smp::cdk::RequestContainer<_Type> Help;
+            // ---- Operations ----
+            Help::template AddIfMissing<void>(
+                handlers,
+                "start",
+                ::Smp::PrimitiveTypeKind::PTK_None,
+                static_cast<void (MonitorServiceGen::*)()>(&MonitorServiceGen::start));
 
-                        // ---- Operations ----
-                        Help::template AddIfMissing<«IF o.returnParameter !== null»«o.returnParameter.type()»«ELSE»void«ENDIF»«FOR param : o.parameter BEFORE ', ' SEPARATOR ', '»«param.type()»«ENDFOR»>(
-             handlers,
-             "start",
-             ::Smp::PrimitiveTypeKind::PTK_None,
-             static_cast<«IF o.returnParameter !== null»«o.returnParameter.type()»«ELSE»void«ENDIF»(«container.name(useGenPattern)»::*)(«FOR param : o.parameter SEPARATOR ', '»«param.type()»«ENDFOR»)«IF o.isConst»const«ENDIF»>(&«container.name(useGenPattern)»::«o.name»));
-
-         if (handlers.find("start") == handlers.end()) {
-             handlers["start"] = [](_Type & component, [[maybe_unused]] ::Smp::IRequest* request) {
-
-             /// Invoke start
-             component.start();
-
-             };
-         }
-
-                        ::esa::ecss::smp::cdk::«t.eClass.name»::PopulateRequestHandlers<_Type>(bluePrint, handlers);
-                    }
-
-
+            ::esa::ecss::smp::cdk::Service::PopulateRequestHandlers<_Type>(bluePrint, handlers);
+        }
 
     } // namespace support
 } // namespace demo

--- a/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/Payload.h
+++ b/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/Payload.h
@@ -29,6 +29,14 @@ namespace demo
            ::Smp::Bool enabled{false};
            ::demo::support::Counter count{0};
 
+            Payload() = default;
+            ~Payload() = default;
+            Payload(const Payload&) = default;
+            Payload(Payload&&) = default;
+            Payload(::Smp::Bool enabled, ::demo::support::Counter count):
+            enabled(enabled), count(count) {}
+            Payload& operator=(const Payload&) = default;
+
             static void _Register(::Smp::Publication::ITypeRegistry* registry);
         };
 

--- a/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/RootModelGen.cpp
+++ b/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/RootModelGen.cpp
@@ -11,8 +11,6 @@
 #include <demo/support/RootModel.h>
 #include <esa/ecss/smp/cdk/EntryPoint.h>
 #include <esa/ecss/smp/cdk/EventSinkArg.h>
-#include <esa/ecss/smp/cdk/Request.h>
-#include <Smp/IPublication.h>
 
 
 namespace demo
@@ -126,9 +124,6 @@ namespace demo
             // Call parent class implementation first
             ::esa::ecss::smp::cdk::Model::Publish(receiver);
 
-            if (requestHandlers.empty()) {
-                PopulateRequestHandlers<RootModelGen>(this, requestHandlers);
-            }
 
             // Publish field name
             receiver->PublishField(
@@ -173,30 +168,6 @@ namespace demo
                 false, // Input
                 false // Output
             );
-            // Publish operation ping
-            auto* op_ping = receiver->PublishOperation(
-                "ping", // Name
-                "", // Description
-                ::Smp::ViewKind::VK_All // View Kind
-            );
-            op_ping->PublishParameter(
-                                "requested", // Name
-                                "", // Description
-                                ::demo::support::Uuid_Ratio, // Type UUID
-                                Smp::Publication::ParameterDirectionKind::PDK_In // Parameter Direction Kind
-                            );
-            op_ping->PublishParameter(
-                                "measured", // Name
-                                "", // Description
-                                ::Smp::Uuids::Uuid_Float64, // Type UUID
-                                Smp::Publication::ParameterDirectionKind::PDK_Out // Parameter Direction Kind
-                            );
-            op_ping->PublishParameter(
-                                "return", // Name
-                                "", // Description
-                                ::Smp::Uuids::Uuid_Bool, // Type UUID
-                                Smp::Publication::ParameterDirectionKind::PDK_Return // Parameter Direction Kind
-                            );
             // Publish Property connected
             receiver->PublishProperty(
                 "connected", // Name
@@ -231,33 +202,6 @@ namespace demo
             // Call parent implementation last, to remove references to the Simulator and its services
             ::esa::ecss::smp::cdk::Model::Disconnect();
         }
-
-        void RootModelGen::DoPublish(::Smp::IPublication*) {
-        }
-
-        void RootModelGen::DoConfigure( ::Smp::Services::ILogger*, ::Smp::Services::ILinkRegistry*){
-        }
-
-        void RootModelGen::DoConnect( ::Smp::ISimulator*){
-        }
-
-        void RootModelGen::DoDisconnect(){
-        }
-
-
-                        void RootModelGen::Invoke(::Smp::IRequest* request) {
-                            if (!request) {
-                                return;
-                            }
-                            if (auto it = _requestHandlers.find(request->GetOperationName());
-                                    it != _requestHandlers.end()) {
-                                it->second(this, request);
-                            } else {
-                                // pass the request down to the base class
-                                ::esa::ecss::smp::cdk::Model::Invoke(request);
-                            }
-                        }
-
 
         const ::Smp::Uuid& RootModelGen::GetUuid() const {
             return Uuid_RootModel;

--- a/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/RootModelGen.h
+++ b/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src-gen/demo/support/RootModelGen.h
@@ -39,7 +39,6 @@ namespace demo
 #include <esa/ecss/smp/cdk/EventSourceVoid.h>
 #include <esa/ecss/smp/cdk/Model.h>
 #include <esa/ecss/smp/cdk/Reference.h>
-#include <map>
 #include <Smp/IComposite.h>
 #include <Smp/IEntryPoint.h>
 #include <Smp/ISimulator.h>
@@ -80,7 +79,7 @@ namespace demo
         RootModelGen& operator=(RootModelGen&&) = delete;
 
         /// Virtual destructor to release memory.
-        ~RootModelGen() override = default;
+        ~RootModelGen() override;
 
         /// Request the Model to publish its fields, properties and
         /// operations against the provided publication receiver.
@@ -114,20 +113,6 @@ namespace demo
         /// @return  Universally Unique Identifier of the Model.
         const ::Smp::Uuid& GetUuid() const override;
 
-                    private:
-                        template <typename _Type> static void PopulateRequestHandlers(_Type* bluePrint, typename ::esa::ecss::smp::cdk::RequestContainer<_Type>::Map& handlers);
-                        static ::esa::ecss::smp::cdk::RequestContainer<RootModelGen>::Map requestHandlers;
-
-                    public:
-                        /// Dynamically invoke an operation using a request object that has
-                        /// been created and filled with parameter values by the caller.
-                        /// @param   request Request object to invoke.
-                        /// @throws  Smp::InvalidOperationName
-                        /// @throws  Smp::InvalidParameterCount
-                        /// @throws  Smp::InvalidParameterType
-                        void Invoke(::Smp::IRequest* request) override;
-
-
         private:
         /// Get connected.
         /// @return Current value of property connected.
@@ -152,34 +137,6 @@ namespace demo
         ::esa::ecss::smp::cdk::Reference<::demo::support::IDevice>* deviceRef;
         ::esa::ecss::smp::cdk::Reference<::demo::support::ChildModel>* childRef;
         };
-
-
-                    template <typename _Type>
-                    void RootModelGen::PopulateRequestHandlers(_Type* bluePrint, typename ::esa::ecss::smp::cdk::RequestContainer<_Type>::Map& handlers)
-                    {
-                        typedef ::esa::ecss::smp::cdk::RequestContainer<_Type> Help;
-
-                        // ---- Operations ----
-                        Help::template AddIfMissing<«IF o.returnParameter !== null»«o.returnParameter.type()»«ELSE»void«ENDIF»«FOR param : o.parameter BEFORE ', ' SEPARATOR ', '»«param.type()»«ENDFOR»>(
-             handlers,
-             "ping",
-             ::Smp::PrimitiveTypeKind::PTK_Bool,
-             static_cast<«IF o.returnParameter !== null»«o.returnParameter.type()»«ELSE»void«ENDIF»(«container.name(useGenPattern)»::*)(«FOR param : o.parameter SEPARATOR ', '»«param.type()»«ENDFOR»)«IF o.isConst»const«ENDIF»>(&«container.name(useGenPattern)»::«o.name»));
-
-         if (handlers.find("ping") == handlers.end()) {
-             handlers["ping"] = [](_Type & component, [[maybe_unused]] ::Smp::IRequest* request) {
-             auto p_requested = static_cast<::demo::support::Ratio>(request->GetParameterValue(req->GetParameterIndex("requested")));
-             ::Smp::Float64 p_measured;
-             /// Invoke ping
-             request->SetReturnValue({::Smp::PrimitiveTypeKind::PTK_Bool, component.ping(p_requested, &p_measured)});
-
-             request->SetParameterValue(request->GetParameterIndex("measured"), p_measured);
-             };
-         }
-
-                        ::esa::ecss::smp::cdk::«t.eClass.name»::PopulateRequestHandlers<_Type>(bluePrint, handlers);
-                    }
-
 
 
     } // namespace support

--- a/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src/demo/support/ChildModel.h
+++ b/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src/demo/support/ChildModel.h
@@ -15,19 +15,34 @@ namespace demo
     {
         class ChildModel: public ChildModelGen {
         public:
-            /// Constructor setting name, description and parent.
-            /// @param name Name of new model instance.
-            /// @param description Description of new model instance.
-            /// @param parent Parent of new model instance.
-            /// @param type_registry Reference to global type registry.
-            ChildModel(
-                    ::Smp::String8 name,
-                    ::Smp::String8 description,
-                    ::Smp::IObject* parent,
-                    ::Smp::Publication::ITypeRegistry* type_registry);
+            /// Re-use parent constructor
+            using ChildModelGen::ChildModelGen;
 
             /// Virtual destructor to release memory.
             ~ChildModel() noexcept override = default;
+
+        private:
+            // ChildModelGen call DoPublish/DoConfigure/DoConnect/DoDisconnect
+            friend class ::demo::support::ChildModelGen;
+
+            /// Publish fields, operations and properties of the Model.
+            /// @param receiver Publication receiver.
+            void DoPublish(::Smp::IPublication* receiver);
+
+            /// Perform any custom configuration of the Model.
+            /// @param logger Logger to use for log messages during Configure().
+            /// @param linkRegistry Link Registry to use for registration of
+            ///         links created during Configure() or later.
+            void DoConfigure(::Smp::Services::ILogger* logger, ::Smp::Services::ILinkRegistry* linkRegistry);
+
+            /// Connect the Model to the simulator and its simulation
+            /// services.
+            /// @param simulator Simulation Environment that hosts the Model.
+            void DoConnect(::Smp::ISimulator* simulator);
+
+            /// Disconnect the Model from the simulator and all its
+            /// simulation services.
+            void DoDisconnect();
 
 
         };

--- a/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src/demo/support/MonitorService.h
+++ b/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src/demo/support/MonitorService.h
@@ -15,21 +15,35 @@ namespace demo
     {
         class MonitorService: public MonitorServiceGen {
         public:
-            /// Constructor setting name, description and parent.
-            /// @param name Name of new model instance.
-            /// @param description Description of new model instance.
-            /// @param parent Parent of new model instance.
-            /// @param type_registry Reference to global type registry.
-            MonitorService(
-                    ::Smp::String8 name,
-                    ::Smp::String8 description,
-                    ::Smp::IObject* parent,
-                    ::Smp::Publication::ITypeRegistry* type_registry);
+            /// Re-use parent constructor
+            using MonitorServiceGen::MonitorServiceGen;
 
             /// Virtual destructor to release memory.
             ~MonitorService() noexcept override = default;
 
-            private:
+        private:
+            // MonitorServiceGen call DoPublish/DoConfigure/DoConnect/DoDisconnect
+            friend class ::demo::support::MonitorServiceGen;
+
+            /// Publish fields, operations and properties of the Service.
+            /// @param receiver Publication receiver.
+            void DoPublish(::Smp::IPublication* receiver);
+
+            /// Perform any custom configuration of the Service.
+            /// @param logger Logger to use for log messages during Configure().
+            /// @param linkRegistry Link Registry to use for registration of
+            ///         links created during Configure() or later.
+            void DoConfigure(::Smp::Services::ILogger* logger, ::Smp::Services::ILinkRegistry* linkRegistry);
+
+            /// Connect the Service to the simulator and its simulation
+            /// services.
+            /// @param simulator Simulation Environment that hosts the Service.
+            void DoConnect(::Smp::ISimulator* simulator);
+
+            /// Disconnect the Service from the simulator and all its
+            /// simulation services.
+            void DoDisconnect();
+
             void start() override;
         };
     } // namespace support

--- a/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src/demo/support/RootModel.h
+++ b/packages/xsmp-profile-esa-cdk/test/expected/generator-cpp/src/demo/support/RootModel.h
@@ -15,21 +15,35 @@ namespace demo
     {
         class RootModel: public RootModelGen {
         public:
-            /// Constructor setting name, description and parent.
-            /// @param name Name of new model instance.
-            /// @param description Description of new model instance.
-            /// @param parent Parent of new model instance.
-            /// @param type_registry Reference to global type registry.
-            RootModel(
-                    ::Smp::String8 name,
-                    ::Smp::String8 description,
-                    ::Smp::IObject* parent,
-                    ::Smp::Publication::ITypeRegistry* type_registry);
+            /// Re-use parent constructor
+            using RootModelGen::RootModelGen;
 
             /// Virtual destructor to release memory.
             ~RootModel() noexcept override = default;
 
-            private:
+        private:
+            // RootModelGen call DoPublish/DoConfigure/DoConnect/DoDisconnect
+            friend class ::demo::support::RootModelGen;
+
+            /// Publish fields, operations and properties of the Model.
+            /// @param receiver Publication receiver.
+            void DoPublish(::Smp::IPublication* receiver);
+
+            /// Perform any custom configuration of the Model.
+            /// @param logger Logger to use for log messages during Configure().
+            /// @param linkRegistry Link Registry to use for registration of
+            ///         links created during Configure() or later.
+            void DoConfigure(::Smp::Services::ILogger* logger, ::Smp::Services::ILinkRegistry* linkRegistry);
+
+            /// Connect the Model to the simulator and its simulation
+            /// services.
+            /// @param simulator Simulation Environment that hosts the Model.
+            void DoConnect(::Smp::ISimulator* simulator);
+
+            /// Disconnect the Model from the simulator and all its
+            /// simulation services.
+            void DoDisconnect();
+
             ::Smp::Bool ping(::demo::support::Ratio requested, ::Smp::Float64* measured) override;
             public:
             void _main() override;

--- a/packages/xsmp-profile-xsmp-sdk/test/expected/generator-cpp/src-gen/demo/support/DeviceBase.h
+++ b/packages/xsmp-profile-xsmp-sdk/test/expected/generator-cpp/src-gen/demo/support/DeviceBase.h
@@ -27,8 +27,8 @@ namespace demo::support
     public:
         static void _Register(::Smp::Publication::ITypeRegistry* registry);
 
-        //«IF constructor»DeviceBase () = default;«ENDIF»
-        //«IF destructor»~DeviceBase () noexcept = default;«ENDIF»
+        //DeviceBase () = default;
+        //~DeviceBase () noexcept = default;
         //DeviceBase (const DeviceBase &) = default;
 
        private:

--- a/packages/xsmp-profile-xsmp-sdk/test/expected/generator-cpp/src-gen/demo/support/DeviceError.h
+++ b/packages/xsmp-profile-xsmp-sdk/test/expected/generator-cpp/src-gen/demo/support/DeviceError.h
@@ -26,8 +26,8 @@ namespace demo::support
     public:
         static void _Register(::Smp::Publication::ITypeRegistry* registry);
 
-        //«IF constructor»DeviceError () = default;«ENDIF»
-        //«IF destructor»~DeviceError () noexcept = default;«ENDIF»
+        //DeviceError () = default;
+        //~DeviceError () noexcept = default;
         //DeviceError (const DeviceError &) = default;
 
 

--- a/packages/xsmp-tas-mdk/test/expected/generator-cpp/include-gen/demo/support/DeviceBase.h
+++ b/packages/xsmp-tas-mdk/test/expected/generator-cpp/include-gen/demo/support/DeviceBase.h
@@ -29,8 +29,8 @@ namespace demo
         public:
             static void _Register(::Smp::Publication::ITypeRegistry* registry);
 
-            //«IF constructor»DeviceBase () = default;«ENDIF»
-            //«IF destructor»~DeviceBase () noexcept = default;«ENDIF»
+            //DeviceBase () = default;
+            //~DeviceBase () noexcept = default;
             //DeviceBase (const DeviceBase &) = default;
 
            private:

--- a/packages/xsmp-tas-mdk/test/expected/generator-cpp/include-gen/demo/support/DeviceError.h
+++ b/packages/xsmp-tas-mdk/test/expected/generator-cpp/include-gen/demo/support/DeviceError.h
@@ -28,8 +28,8 @@ namespace demo
         public:
             static void _Register(::Smp::Publication::ITypeRegistry* registry);
 
-            //«IF constructor»DeviceError () = default;«ENDIF»
-            //«IF destructor»~DeviceError () noexcept = default;«ENDIF»
+            //DeviceError () = default;
+            //~DeviceError () noexcept = default;
             //DeviceError (const DeviceError &) = default;
 
 

--- a/packages/xsmp/src/generator/cpp/gap-pattern-generator.ts
+++ b/packages/xsmp/src/generator/cpp/gap-pattern-generator.ts
@@ -375,8 +375,8 @@ export abstract class GapPatternCppGenerator extends CppGenerator {
         public:
             static void _Register(::Smp::Publication::ITypeRegistry* registry);
             
-            //«IF constructor»${this.name(type, gen)} () = default;«ENDIF»
-            //«IF destructor»~${this.name(type, gen)} () noexcept = default;«ENDIF»
+            //${this.name(type, gen)} () = default;
+            //~${this.name(type, gen)} () noexcept = default;
             //${this.name(type, gen)} (const ${this.name(type, gen)} &) = default;
             
            ${this.declareMembersGen(type, VisibilityKind.public, gen)}

--- a/packages/xsmp/test/fixtures/profile-generators/catalogue.xsmpcat
+++ b/packages/xsmp/test/fixtures/profile-generators/catalogue.xsmpcat
@@ -59,6 +59,7 @@ namespace demo
         public interface IDevice
         {
             constant Bool Ready = false
+            @View(ViewKind.VK_All)
             def Bool ping(in Ratio requested, out Float64 measured)
             property Bool connected
         }
@@ -73,6 +74,7 @@ namespace demo
         public service MonitorService
         {
             field Bool running = false
+            @View(ViewKind.VK_All)
             def void start()
             property Bool Running -> running
         }
@@ -99,6 +101,7 @@ namespace demo
             eventsink TickEvent onTick
             eventsource VoidEvent onDone
 
+            @View(ViewKind.VK_All)
             def Bool ping(in Ratio requested, out Float64 measured)
             property Bool connected -> connectedState
         }


### PR DESCRIPTION
## Summary

Fixes the ESA-CDK profile generator migration from the old Xtend implementation.

This updates the generated request-handler code to use the ESA-CDK `RequestContainer` API correctly, filters operations with `out` / `inout` parameters from dynamic invocation, and restores valid C++11 generation for structure default initialization.

## Root Cause

The TypeScript migration still contained Xtend-era/manual request-handler generation patterns that did not match ESA-CDK's `RequestContainer` / `IRequestHandler` API. ESA-CDK dynamic request invocation only supports simple input parameters, so operations with `out` / `inout` parameters should not be generated as request handlers.

## Changes

- Use `RequestContainer::AddIfMissing` and `IRequestHandler::Execute` for generated ESA-CDK request handlers.
- Filter ESA-CDK dynamically invokable operations to explicit `@View` operations with simple non-string `in` parameters only.
- Keep SMP property publication separate from dynamic operation invocation.
- Add C++11 constructors for generated ESA-CDK structures with field defaults so aggregate-style field initialization compiles.
- Update profile-generator fixture and expected generated C++ outputs.

## Related Issue

Related to ThalesGroup/xsmp-modeler-core#189.

## Validation

- `npm run build -w @xsmp/profile-esa-cdk`
- `npx vitest run packages/xsmp-profile-esa-cdk/test --config vitest.config.ts`
- `g++ -std=c++11 -fsyntax-only` over all ESA-CDK generated `.cpp` files
- Full temporary CMake/Ninja build linking separated `smp`, `extensions`, `cdk`, and generated `profile_generators` shared libraries with real Boost/fmt/JNI and cloned `nlohmann/json`
