### PR TITLE
fix xsmpcat type scope filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -188,22 +188,22 @@
             }
         },
         "node_modules/@azure/msal-browser": {
-            "version": "5.10.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.10.1.tgz",
-            "integrity": "sha512-hTbvOi9Ko2Jvn+G/fSmjzHf9WbNcf/o3epMtbeGx/pMwMrVAbi6OgCJVeCfsAb8IybSRpaCSc4EDRlYAhgngUQ==",
+            "version": "5.11.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
+            "integrity": "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "16.6.1"
+                "@azure/msal-common": "16.6.2"
             },
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-common": {
-            "version": "16.6.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.1.tgz",
-            "integrity": "sha512-VxKdEtUwDuLD0F1hOQP7kye0YadZxFJfv37Em440geEf/w9uggKnHpRrqwZJOdxmPUOdhZ9kyRtKuAJW8wUcRg==",
+            "version": "16.6.2",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+            "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -211,13 +211,13 @@
             }
         },
         "node_modules/@azure/msal-node": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.1.tgz",
-            "integrity": "sha512-tmQiQ2HvtzaeLqYGy3BemiPOSGPY4wCy1IW5zDWITKSs/s35WEd7Zij/hCxvUdAOzj6U3qnyaGbYXY91ortFEQ==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+            "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "16.6.1",
+                "@azure/msal-common": "16.6.2",
                 "jsonwebtoken": "^9.0.0"
             },
             "engines": {
@@ -225,13 +225,13 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -247,9 +247,9 @@
             "license": "MIT"
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -257,9 +257,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -267,13 +267,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -283,14 +283,14 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1298,6 +1298,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1315,6 +1318,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1332,6 +1338,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1349,6 +1358,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1366,6 +1378,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1383,6 +1398,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1664,24 +1682,24 @@
             "license": "MIT"
         },
         "node_modules/@textlint/ast-node-types": {
-            "version": "15.7.0",
-            "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.7.0.tgz",
-            "integrity": "sha512-wZILFXsRf2gGK9k0Fr69GUdfuZV9CrtByga8Qkw0CLyKBBfZXdNQlJF2XdZ2Ju9ggrTbAWehGo0RjCsAHSBWtA==",
+            "version": "15.7.1",
+            "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.7.1.tgz",
+            "integrity": "sha512-Wii5UgUKFEh9Uv6wbq1zr4/Kf+dtjiUuzPrrXzKp8H+ifkvKNzi23V4Nz+6wVyHQn5T28AFuc8VH8OtzvGYecA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@textlint/linter-formatter": {
-            "version": "15.7.0",
-            "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.7.0.tgz",
-            "integrity": "sha512-wrpDID1bfBt5XIUXtgw8NmGIuRFansWAtX1FLHv/zLRt3sgxCFnyon88SbhPOPITEgIlfFcsESElCSLzWySubQ==",
+            "version": "15.7.1",
+            "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.7.1.tgz",
+            "integrity": "sha512-TdwZ/debWYFD05K3CcoHtwvnCrza29wZxD+BjDTk/V5N7iRqkK1dTTHSD4A8AIgROLiDkHJmIKQbasbmsg8AvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@azu/format-text": "^1.0.2",
                 "@azu/style-format": "^1.0.1",
-                "@textlint/module-interop": "15.7.0",
-                "@textlint/resolver": "15.7.0",
-                "@textlint/types": "15.7.0",
+                "@textlint/module-interop": "15.7.1",
+                "@textlint/resolver": "15.7.1",
+                "@textlint/types": "15.7.1",
                 "chalk": "^4.1.2",
                 "debug": "^4.4.3",
                 "js-yaml": "^4.1.1",
@@ -1724,27 +1742,27 @@
             }
         },
         "node_modules/@textlint/module-interop": {
-            "version": "15.7.0",
-            "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.7.0.tgz",
-            "integrity": "sha512-+VdoeGFH66OasijhoO7D3OSrqTfJNAIH2OoQHEc5StlO0dqDO2JfZStCbuBPP/ZbpJvuYdoERBP+nKqTAT24vA==",
+            "version": "15.7.1",
+            "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.7.1.tgz",
+            "integrity": "sha512-Jg+sQW2L/cRJypk59wtcMUVVpt8vmit5ZMT3gUnFwevP3A6Qp1HfOtUy9ObT4hBX3lOSGT/ekcCDxR1pL7uH1g==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@textlint/resolver": {
-            "version": "15.7.0",
-            "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.7.0.tgz",
-            "integrity": "sha512-f94t/8ZR97uhOu2KvBujMGGtfdoJQZLjDNN7+7PNLaTjCtGn+XrqKjSP9lzXgBhUbKSygRN8AlrCMx9S70FHKw==",
+            "version": "15.7.1",
+            "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.7.1.tgz",
+            "integrity": "sha512-8XnO0pgF6mXnm41VvWmBbEIdGPhiCUt31uLZkOis1ECeg/1SoUcIT6Mx/F0e1rukq8l0UlOSeY9a31CsvRMK0g==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@textlint/types": {
-            "version": "15.7.0",
-            "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.7.0.tgz",
-            "integrity": "sha512-soItNoFZ8Ua4WCgWwOaTEEyTkX7bjArwVxhN1F2UySeqPsP8QeRiKNUjAIfWQFHddTY6UYR1sHaEh+O0sQPv0Q==",
+            "version": "15.7.1",
+            "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.7.1.tgz",
+            "integrity": "sha512-Vye/GmFNBTgVzZFtIFJTmLB+s2A7oIADxNG6r9UhfPuY+Czv0z5G3xeyFZZudPlfxURsKUyPIU5XsjOFqVp33A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@textlint/ast-node-types": "15.7.0"
+                "@textlint/ast-node-types": "15.7.1"
             }
         },
         "node_modules/@tybys/wasm-util": {
@@ -1798,9 +1816,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.8.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-            "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+            "version": "25.9.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+            "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2591,9 +2609,9 @@
             }
         },
         "node_modules/ast-v8-to-istanbul": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
-            "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+            "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2702,9 +2720,9 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3427,9 +3445,9 @@
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4340,9 +4358,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4735,9 +4753,19 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -5124,6 +5152,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5145,6 +5176,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5166,6 +5200,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5187,6 +5224,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5243,10 +5283,20 @@
             }
         },
         "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+            "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
@@ -5389,15 +5439,25 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.1.1",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+            "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
+                "linkify-it": "^5.0.1",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"
@@ -5969,9 +6029,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.3.6",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-            "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -7045,9 +7105,9 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-            "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7280,9 +7340,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
+            "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7563,9 +7623,9 @@
             }
         },
         "node_modules/vscode-jsonrpc": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+            "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
@@ -7586,9 +7646,9 @@
             }
         },
         "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -7626,6 +7686,15 @@
             "dependencies": {
                 "vscode-jsonrpc": "8.2.0",
                 "vscode-languageserver-types": "3.17.5"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol/node_modules/vscode-jsonrpc": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/vscode-languageserver-textdocument": {
@@ -7914,13 +7983,12 @@
             }
         },
         "node_modules/yauzl": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
-            "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.2.tgz",
+            "integrity": "sha512-Md9ankxxN23wncAN8s7+Tn3Co52zLUPMtnrLAbVCnfG5d2tKBFfmygYSgXlqFgXObtzIgqkx7aNgDBpso9+4qA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "buffer-crc32": "~0.2.3",
                 "pend": "~1.2.0"
             },
             "engines": {

--- a/packages/xsmp/src/lsp/xsmpcat-completion-provider.ts
+++ b/packages/xsmp/src/lsp/xsmpcat-completion-provider.ts
@@ -488,14 +488,21 @@ export class XsmpcatCompletionProvider extends XsmpCompletionProviderBase {
         if (!owner) {
             return undefined;
         }
+        const referenceExpression: ast.NamedElementReference = {
+            $type: ast.NamedElementReference.$type,
+            $container: owner,
+            $containerProperty: ast.isConstant(owner) ? ast.Constant.value : ast.Field.default,
+            value: {
+                $refText: '',
+                ref: undefined,
+            },
+        };
+        AstUtils.assignMandatoryProperties(this.astReflection, referenceExpression);
         return {
             owner,
             refInfo: {
-                reference: {
-                    $refText: '',
-                    ref: undefined,
-                },
-                container: owner,
+                reference: referenceExpression.value!,
+                container: referenceExpression,
                 property: ast.NamedElementReference.value,
             },
         };

--- a/packages/xsmp/src/references/xsmpcat-scope-provider.ts
+++ b/packages/xsmp/src/references/xsmpcat-scope-provider.ts
@@ -11,24 +11,24 @@ export class XsmpcatScopeProvider implements ScopeProvider {
     protected readonly reflection: AstReflection;
     protected readonly indexManager: IndexManager;
     protected readonly typeProvider: XsmpTypeProvider;
-    protected readonly globalScopeCache: WorkspaceCache<URI, Scope>;
+    protected readonly globalScopeCache: WorkspaceCache<URI, Map<string, Scope>>;
     protected readonly contexts: Set<ReferenceInfo['reference']> = new Set<ReferenceInfo['reference']>();
-    protected readonly precomputedCache: DocumentCache<AstNode, Map<string, AstNodeDescription>>;
+    protected readonly precomputedCache: DocumentCache<AstNode, AstNodeDescription[]>;
     protected readonly projectManager: ProjectManager;
 
     constructor(services: XsmpServices) {
         this.reflection = services.shared.AstReflection;
         this.indexManager = services.shared.workspace.IndexManager;
         this.typeProvider = services.shared.TypeProvider;
-        this.globalScopeCache = new WorkspaceCache<URI, Scope>(services.shared);
-        this.precomputedCache = new DocumentCache<AstNode, Map<string, AstNodeDescription>>(services.shared);
+        this.globalScopeCache = new WorkspaceCache<URI, Map<string, Scope>>(services.shared);
+        this.precomputedCache = new DocumentCache<AstNode, AstNodeDescription[]>(services.shared);
         this.projectManager = services.shared.workspace.ProjectManager;
     }
 
     protected collectScopesFromNode(node: AstNode, scopes: Array<Map<string, AstNodeDescription>>,
-        document: LangiumDocument) {
+        document: LangiumDocument, referenceType: string) {
 
-        const precomputed = this.getPrecomputedScope(node, document);
+        const precomputed = this.getPrecomputedScope(node, document, referenceType);
         if (precomputed.size > 0) {
             scopes.push(precomputed);
         }
@@ -37,30 +37,30 @@ export class XsmpcatScopeProvider implements ScopeProvider {
             case ast.Service.$type: {
                 const component = node as ast.Component;
                 if (component.base) {
-                    this.collectScopesFromReference(component.base, scopes);
+                    this.collectScopesFromReference(component.base, scopes, referenceType);
                 }
-                component.interface.forEach(i => this.collectScopesFromReference(i, scopes));
+                component.interface.forEach(i => this.collectScopesFromReference(i, scopes, referenceType));
                 break;
             }
             case ast.Interface.$type: {
-                (node as ast.Interface).base.forEach(i => this.collectScopesFromReference(i, scopes));
+                (node as ast.Interface).base.forEach(i => this.collectScopesFromReference(i, scopes, referenceType));
                 break;
             }
             case ast.Class.$type:
             case ast.Exception.$type: {
                 const clazz = node as ast.Class;
                 if (clazz.base)
-                    this.collectScopesFromReference(clazz.base, scopes);
+                    this.collectScopesFromReference(clazz.base, scopes, referenceType);
                 break;
             }
         }
     }
-    protected collectScopesFromReference(node: Reference, scopes: Array<Map<string, AstNodeDescription>>) {
+    protected collectScopesFromReference(node: Reference, scopes: Array<Map<string, AstNodeDescription>>, referenceType: string) {
         // Check if the node is currently processed to avoid cyclic dependency
         if (!this.contexts.has(node) && node.ref) {
             this.contexts.add(node);
             try {
-                this.collectScopesFromNode(node.ref, scopes, AstUtils.getDocument(node.ref));
+                this.collectScopesFromNode(node.ref, scopes, AstUtils.getDocument(node.ref), referenceType);
             }
             finally {
                 // Remove the context
@@ -85,6 +85,7 @@ export class XsmpcatScopeProvider implements ScopeProvider {
         let parent: Scope;
 
         const scopes: Array<Map<string, AstNodeDescription>> = [];
+        const referenceType = this.reflection.getReferenceType(context);
 
         if (ast.DesignatedInitializer.$type === context.container.$type && context.property === ast.DesignatedInitializer.field) {
             if (context.container.$container) {
@@ -93,7 +94,7 @@ export class XsmpcatScopeProvider implements ScopeProvider {
                     case ast.Structure.$type:
                     case ast.Class.$type:
                     case ast.Exception.$type:
-                        this.collectScopesFromNode(type, scopes, AstUtils.getDocument(type));
+                        this.collectScopesFromNode(type, scopes, AstUtils.getDocument(type), referenceType);
                         parent = EMPTY_SCOPE;
                         break;
                     default: return EMPTY_SCOPE;
@@ -106,9 +107,9 @@ export class XsmpcatScopeProvider implements ScopeProvider {
         else {
             let currentNode = context.container.$container;
             const document = AstUtils.getDocument(context.container);
-            parent = this.getGlobalScope(document);
+            parent = this.getGlobalScope(document, referenceType);
             while (currentNode) {
-                this.collectScopesFromNode(currentNode, scopes, document);
+                this.collectScopesFromNode(currentNode, scopes, document, referenceType);
                 currentNode = currentNode.$container;
             }
         }
@@ -123,19 +124,32 @@ export class XsmpcatScopeProvider implements ScopeProvider {
     /**
      * Create a global scope filtered for the given referenceType and on visibles projects URIs
      */
-    protected getGlobalScope(document: LangiumDocument): Scope {
-        return this.globalScopeCache.get(document.uri, () => new XsmpGlobalScope(this.indexManager.allElements(undefined, this.projectManager.getVisibleUris(document))));
+    protected getGlobalScope(document: LangiumDocument, referenceType: string): Scope {
+        const globalScopes = this.globalScopeCache.get(document.uri, () => new Map<string, Scope>());
+        let scope = globalScopes.get(referenceType);
+        if (!scope) {
+            scope = new XsmpGlobalScope(this.indexManager.allElements(referenceType, this.projectManager.getVisibleUris(document)));
+            globalScopes.set(referenceType, scope);
+        }
+        return scope;
     }
 
-    protected getPrecomputedScope(node: AstNode, document: LangiumDocument): Map<string, AstNodeDescription> {
-        return this.precomputedCache.get(document.uri, node, () => {
-            const precomputed = new Map<string, AstNodeDescription>();
+    protected getPrecomputedScope(node: AstNode, document: LangiumDocument, referenceType: string): Map<string, AstNodeDescription> {
+        const descriptions = this.precomputedCache.get(document.uri, node, () => {
+            const precomputed: AstNodeDescription[] = [];
             if (document.localSymbols?.has(node)) {
                 for (const element of document.localSymbols.getStream(node)) {
-                    precomputed.set(element.name, element);
+                    precomputed.push(element);
                 }
             }
             return precomputed;
         });
+        const precomputed = new Map<string, AstNodeDescription>();
+        for (const element of descriptions) {
+            if (this.reflection.isSubtype(element.type, referenceType)) {
+                precomputed.set(element.name, element);
+            }
+        }
+        return precomputed;
     }
 }

--- a/packages/xsmp/test/linking/xsmpcat-linking.test.ts
+++ b/packages/xsmp/test/linking/xsmpcat-linking.test.ts
@@ -3,7 +3,7 @@ import { EmptyFileSystem, type LangiumDocument } from "langium";
 import { expandToString as s } from "langium/generate";
 import { clearDocuments, parseHelper } from "langium/test";
 import { createXsmpServices } from 'xsmp';
-import { Catalogue, isCatalogue } from 'xsmp/ast-partial';
+import { Catalogue, isCatalogue, isClass, isNamespace, isOperation } from 'xsmp/ast-partial';
 
 let services: ReturnType<typeof createXsmpServices>;
 let parse: ReturnType<typeof parseHelper<Catalogue>>;
@@ -49,6 +49,43 @@ describe('Linking tests', () => {
             ns
             ns2
         `);
+    });
+
+    test('operation names do not shadow type names', async () => {
+        document = await parse(`
+            catalogue test
+
+            namespace ns
+            {
+                /** @uuid 830b6e43-91ac-408a-a991-8f34c071bae5 */
+                class Toto
+                {
+                    @Constructor
+                    def void Toto()
+
+                    def void Copy(Toto other)
+                }
+            }
+        `);
+
+        const namespace = document.parseResult.value.elements[0];
+        if (!namespace || !isNamespace(namespace)) {
+            throw new Error(`Root element is a ${namespace?.$type ?? 'undefined'}, expected a namespace.`);
+        }
+
+        const clazz = namespace.elements[0];
+        if (!clazz || !isClass(clazz)) {
+            throw new Error(`Namespace element is a ${clazz?.$type ?? 'undefined'}, expected a class.`);
+        }
+
+        const constructor = clazz.elements.find(element => isOperation(element) && element.name === 'Toto');
+        const copy = clazz.elements.find(element => isOperation(element) && element.name === 'Copy');
+
+        expect(checkDocumentValid(document)).toBeUndefined();
+        expect(copy).toBeDefined();
+        expect(constructor).toBeDefined();
+        expect(copy?.parameter[0]?.type.ref).toBe(clazz);
+        expect(copy?.parameter[0]?.type.ref).not.toBe(constructor);
     });
 });
 

--- a/packages/xsmp/test/validating/xsmpcat-validating.expected.txt
+++ b/packages/xsmp/test/validating/xsmpcat-validating.expected.txt
@@ -1,4 +1,7 @@
 [105:127..105:134]: Could not resolve reference to Type named 'Invalid'.
+[111:61..111:65]: Could not resolve reference to Field named 'CST0'.
+[144:11..144:18]: Could not resolve reference to Field named 'MyModel'.
+[145:12..145:19]: Could not resolve reference to Field named 'MyModel'.
 [9:10..9:15]: A name shall not be an ISO/ANSI C++ keyword.
 [3:9..3:21]: Invalid date format (e.g: 1970-01-01T00:00:00Z).
 [9:0..9:9]: This Catalogue is not contained in a project.
@@ -68,11 +71,9 @@
 [105:74..105:82]: Deprecated.
 [105:100..105:110]: A Parameter shall not be both ByPointer and ByReference.
 [105:148..105:152]: The PrimitiveType Smp.Bool is not visible.
-[111:61..111:65]: Expecting a Field.
 [107:8..107:15]: A Property of an Interface shall not be static.
 [108:8..108:16]: A Property shall not be both Static and Virtual.
 [109:8..109:17]: A Property shall not be both Static and Abstract.
-[107:8..107:15]: A Property shall not be Static if the attached field is not Static.
 [115:4..115:9]: Missing Type UUID.
 [115:26..115:33]: Cyclic dependency detected.
 [115:58..115:69]: Duplicated interface.
@@ -100,10 +101,8 @@
 [136:8..136:18]: A Property shall not be both ByPointer and ByReference.
 [142:11..142:12]: Deprecated: do not use
 [142:11..142:12]: Field is not an Input.
-[144:11..144:18]: Expecting a Field.
 [143:12..143:13]: Deprecated: do not use
 [143:12..143:13]: Field is not an Output.
-[145:12..145:19]: Expecting a Field.
 [147:17..147:24]: A Reference in ECSS_SMP_2020 shall target an Interface.
 [151:29..151:31]: Lower bound shall be a positive number or 0.
 [153:29..153:31]: Lower bound shall be a positive number or 0.


### PR DESCRIPTION
## Summary

- Filter xsmpcat local and global scopes by the expected Langium reference type.
- Keep xsmpcat scope lookup tolerant of synthetic completion contexts used to list visible constants.
- Update the xsmpcat validation expected output now that invalid field references no longer resolve to non-field symbols.
- Add a linking regression for issue #178 where a constructor/operation named like its class shadowed the class type in an operation parameter.

## Root Cause

`XsmpcatScopeProvider` collected local precomputed symbols by name without checking the type expected by the current reference. Class members are part of the class local scope, so an operation named `Toto` could shadow the class type `Toto` when resolving `Copy(Toto other)`.

The first fix also exposed synthetic completion contexts that are not real grammar references. Those contexts now fall back to the previous unfiltered lookup behavior, while real references remain type-filtered.

## Validation

- `npx vitest run packages/xsmp/test/lsp/xsmpcat-completion-provider.test.ts packages/xsmp/test/validating/xsmpcat-validating.test.ts --config vitest.config.ts`
- `npm run test:raw`
- `npm run lint -w xsmp`
- `npm run build -w xsmp`
- `npm run coverage:raw`
- `npm run build`

Fixes #178
